### PR TITLE
fix(readme): correct broken tests link to use right repo name

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ develop decentralized applications and deliver compelling experiences.
 [hanzo]:            https://hanzo.ai
 [solidity]:         https://solidity.readthedocs.io
 [truffle]:          http://truffleframework.com/
-[tests]:            https://github.com/hanzoai/solidity/tree/master/test
+[tests]:            https://github.com/hanzoai/contracts/tree/master/test
 
 [build-img]:        https://img.shields.io/travis/hanzoai/solidity.svg
 [build-url]:        https://travis-ci.org/hanzoai/solidity


### PR DESCRIPTION
### What
Fix the `[tests]` reference URL in README.md — it points to `hanzoai/solidity` but the actual repo is `hanzoai/contracts`.

### Why
The link is broken; clicking "test suite" in the README 404s because the repository slug is wrong.

Small, scoped fix from kcolbchain contrib-bot.